### PR TITLE
Alphafold mergerankings

### DIFF
--- a/containers/alphafold-data/Dockerfile
+++ b/containers/alphafold-data/Dockerfile
@@ -76,7 +76,7 @@ COPY --from=build /usr/local/bin /usr/bin
 COPY alphafold /app/alphafold
 COPY hhsearch.py hmmsearch.py /app/alphafold/alphafold/data/tools/
 COPY stereo_chemical_props.txt /app/alphafold/alphafold/common/
-COPY create_msa_monomer.py search_templates.py generate_features.py new_pipelines.py update_locations.py filter_pdb.py /opt/
+COPY create_msa_monomer.py search_templates.py generate_features.py new_pipelines.py update_locations.py filter_pdb.py merge_rankings.py /opt/
 
 # Install python and other dependencies
 RUN yum upgrade -y \

--- a/containers/alphafold-data/merge_rankings.py
+++ b/containers/alphafold-data/merge_rankings.py
@@ -1,19 +1,20 @@
 import json
 import sys
 import os
+import shutil
+import glob
 from argparse import ArgumentParser
-
 
 
 def get_ranking_confidence(item):
     return item[1].get('ranking_confidence',0)
 
 
-def get_metrics_jsons(msa_dirs):
+def get_metrics_jsons(model_dirs):
     metrics_dicts = []
 
-    for msa_dir in msa_dirs:
-        metrics_path = os.path.join(msa_dir,'metrics.json')
+    for model_dir in model_dirs:
+        metrics_path = os.path.join(model_dir,'metrics.json')
         with open(metrics_path,'r') as f:
             metrics_dicts.append(json.load(f))
 
@@ -29,7 +30,7 @@ def sort_results(metrics_dicts):
     sorted_results = []
     for i in sorted(model_results.items(), key=get_ranking_confidence, reverse=True):
         i[1]['prediction'] = i[0]
-        sorted_results.append(i)
+        sorted_results.append(i[1])
 
     return sorted_results
 
@@ -40,19 +41,36 @@ def write_results(sorted_results, output_dir):
         json.dump(sorted_results, f, indent=4)
 
 
-def merge_rankings(msa_dirs, output_dir):
-    print (msa_dirs)
-    metrics_dicts = get_metrics_jsons(msa_dirs)
+def merge_rankings(model_dirs, output_dir):
+    print (model_dirs)
+    metrics_dicts = get_metrics_jsons(model_dirs)
     sorted_results = sort_results(metrics_dicts)
     write_results(sorted_results, output_dir)
+    return sorted_results
 
 
+def copy_top_hit(top_hit, model_dirs, output_dir):
+    prediction = top_hit['prediction']
+    
+    files_to_copy = []
+    for model_dir in model_dirs:
+        files_to_copy.extend(glob.glob(os.path.join(model_dir, '*' + prediction + '*')))
+    
+    for filename in files_to_copy:
+        file_destination = os.path.join(output_dir,'top_hit_' + os.path.basename(filename))
+        print ('Copying %s to %s' % (filename, file_destination))
+        shutil.copy(filename, file_destination, follow_symlinks=True)
+    
+    
 def main():
     parser = ArgumentParser()
-    parser.add_argument("--msa_dirs", nargs='+', required=True)
+    parser.add_argument("--model_dirs", nargs='+', required=True)
     parser.add_argument("--output_dir", help="Output directory", required=True)
     args = parser.parse_args()
-    merge_rankings(args.msa_dirs, args.output_dir)
+    sorted_results = merge_rankings(args.model_dirs, args.output_dir)
+    
+    # Next find the top performing hit and rearrange outputs
+    copy_top_hit(sorted_results[0], args.model_dirs, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/containers/alphafold-data/merge_rankings.py
+++ b/containers/alphafold-data/merge_rankings.py
@@ -1,0 +1,59 @@
+import json
+import sys
+import os
+from argparse import ArgumentParser
+
+
+
+def get_ranking_confidence(item):
+    return item[1].get('ranking_confidence',0)
+
+
+def get_metrics_jsons(msa_dirs):
+    metrics_dicts = []
+
+    for msa_dir in msa_dirs:
+        metrics_path = os.path.join(msa_dir,'metrics.json')
+        with open(metrics_path,'r') as f:
+            metrics_dicts.append(json.load(f))
+
+    return metrics_dicts
+
+
+def sort_results(metrics_dicts):
+    model_results = {}
+    for metrics in metrics_dicts:
+        for k, v in metrics['model_results'].items():
+            model_results[k] = v
+
+    sorted_results = []
+    for i in sorted(model_results.items(), key=get_ranking_confidence, reverse=True):
+        i[1]['prediction'] = i[0]
+        sorted_results.append(i)
+
+    return sorted_results
+
+
+def write_results(sorted_results, output_dir):
+    rankings_path = os.path.join(output_dir, 'rankings.json')
+    with open(rankings_path, 'w') as f:
+        json.dump(sorted_results, f, indent=4)
+
+
+def merge_rankings(msa_dirs, output_dir):
+    print (msa_dirs)
+    metrics_dicts = get_metrics_jsons(msa_dirs)
+    sorted_results = sort_results(metrics_dicts)
+    write_results(sorted_results, output_dir)
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--msa_dirs", nargs='+', required=True)
+    parser.add_argument("--output_dir", help="Output directory", required=True)
+    args = parser.parse_args()
+    merge_rankings(args.msa_dirs, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/alphafold-multimer/searches.nf
+++ b/modules/alphafold-multimer/searches.nf
@@ -4,7 +4,7 @@ process SearchUniref90 {
     label 'data'
     cpus 8
     memory '32 GB'
-    publishDir "/mnt/workflow/pubdir"
+    publishDir "/mnt/workflow/pubdir/msa"
 
     input:
         tuple val(id), path(fasta_path)
@@ -37,7 +37,7 @@ process SearchUniprot {
     label 'data'
     cpus 8
     memory '32 GB'
-    publishDir "/mnt/workflow/pubdir"
+    publishDir "/mnt/workflow/pubdir/msa"
 
     input:
         tuple val(id), path(fasta_path)
@@ -70,7 +70,7 @@ process SearchMgnify {
     label 'data'
     cpus 8
     memory '64 GB'
-    publishDir "/mnt/workflow/pubdir"
+    publishDir "/mnt/workflow/pubdir/msa"
 
     input:
         tuple val(id), path(fasta_path)
@@ -104,7 +104,7 @@ process SearchBFD {
     memory { 64.GB * Math.pow(2, task.attempt) }
     maxRetries 1
     errorStrategy 'retry'
-    publishDir "/mnt/workflow/pubdir"
+    publishDir "/mnt/workflow/pubdir/msa"
 
     input:
         tuple val(id), path(fasta_path)
@@ -138,7 +138,7 @@ process SearchTemplatesTask {
     label 'data'
     cpus 2
     memory '8 GB'
-    publishDir "/mnt/workflow/pubdir"
+    publishDir "/mnt/workflow/pubdir/msa"
 
     input:
         tuple val(id), path (msa_path)

--- a/modules/alphafold2/searches.nf
+++ b/modules/alphafold2/searches.nf
@@ -5,7 +5,7 @@ process SearchUniref90 {
     label 'data'
     cpus 8
     memory '32 GB'
-    publishDir "/mnt/workflow/pubdir/${id}"
+    publishDir "/mnt/workflow/pubdir/${id}/msa"
 
     input:
         tuple val(id), path(fasta_path)
@@ -39,7 +39,7 @@ process SearchMgnify {
     label 'data'
     cpus 8
     memory '64 GB'
-    publishDir "/mnt/workflow/pubdir/${id}"
+    publishDir "/mnt/workflow/pubdir/${id}/msa"
 
     input:
         tuple val(id), path(fasta_path)
@@ -77,7 +77,7 @@ process SearchBFD {
     maxRetries 1
     errorStrategy 'retry'
     
-    publishDir "/mnt/workflow/pubdir/${id}"
+    publishDir "/mnt/workflow/pubdir/${id}/msa"
 
     input:
         tuple val(id), path(fasta_path)
@@ -113,7 +113,7 @@ process SearchTemplatesTask {
     label 'data'
     cpus 2
     memory '8 GB'
-    publishDir "/mnt/workflow/pubdir/${id}"
+    publishDir "/mnt/workflow/pubdir/${id}/msa"
 
     input:
         tuple val(id), path (msa_path)

--- a/workflows/alphafold-multimer/main.nf
+++ b/workflows/alphafold-multimer/main.nf
@@ -63,6 +63,8 @@ workflow {
     // Predict. Five separate models
     model_nums = Channel.of(0,1,2,3,4)
     AlphaFoldMultimerInference(params.target_id, GenerateFeaturesTask.out.features, params.alphafold_model_parameters, model_nums, params.random_seed, params.run_relax)
+
+    MergeRankings(AlphaFoldMultimerInference.out.results.collect())
 }
 
 // Check the inputs and get size etc
@@ -150,8 +152,8 @@ process AlphaFoldMultimerInference {
         val run_relax
 
     output:
-        path "metrics.json", emit: metrics
-        path "output/*", emit: results
+        tuple (path "metrics.json"), path ("output/*"), emit: results
+        //path "output/*", emit: results
     
     script:
     """
@@ -167,4 +169,17 @@ process AlphaFoldMultimerInference {
     mv output/metrics.json .
     rm -rf output/msas
     """
+}
+
+
+//Merge Rankings
+process MergeRankings {
+    cpus 2
+    memory 4.GB
+    publishDir "/mnt/workflow/pubdir/final"
+
+    input:
+    tuple (path "metrics.json"), path ("output/*")
+
+    output:
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/drug-discovery-workflows/issues/13

*Description of changes:*
This PR merges the rankings output from AlphaFold. While the process works faster when scaled out, it is harder to evaluate the top hit across all because each set of rankings is determined separately.

This PR introduces a new step `mergeRankings` at the end to collect all together. It also adds `top_hit*` for all of files associated with the highest-scoring prediction and puts it in the top level of the prediction.
* In `monomer`: this is found under `pubdir/${id}`
* In `multimer`: this is found under `pubdir`

The PR also adds a `rankings.json` with the following format:
```
[
  {
    "plddt": 81.025,
    "ptm": 0.849,
    "max_predicted_aligned_error": 31.75,
    "ranking_confidence": 0.841,
    "prediction": "model_4_multimer_v3_pred_2"
  },
  {
    "plddt": 80.761,
    "ptm": 0.846,
    "max_predicted_aligned_error": 31.75,
    "ranking_confidence": 0.839,
    "prediction": "model_2_multimer_v3_pred_3"
  },
  ...
]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
