### PR TITLE
Updated Dockerfile to solve the wget certificate error

### DIFF
--- a/containers/alphafold-data/Dockerfile
+++ b/containers/alphafold-data/Dockerfile
@@ -51,7 +51,7 @@ popd
 
 # Compile kalign2 from source
 RUN pushd /tmp && \
-wget http://msa.sbc.su.se/downloads/kalign/current.tar.gz \
+wget http://msa.sbc.su.se/downloads/kalign/current.tar.gz --no-check-certificate \
 && mkdir -p /tmp/kalign2/build \
 && tar -xvzf current.tar.gz -C /tmp/kalign2 \
 && pushd /tmp/kalign2 \


### PR DESCRIPTION
The certificate has expired

*Issue #, if available:* Not available

*Description of changes:*
The above PR solve the certification error while building docker file. It was certification expired error. and by adding --no-check-certificate flag able to build image.

```bash
[build 4/6] RUN pushd /tmp && wget http://msa.sbc.su.se/downloads/kalign/current.tar.gz && mkdir -p /tmp/kalign2/build && tar -xvzf current.tar.gz -C /tmp/kalign2 && pushd /tmp/kalign2 && ./configure && make && make install && popd && rm -rf /tmp/kalign2 && popd:                                              
0.192 /tmp /                                                                                                                                                
0.195 --2024-07-09 10:26:50--  http://msa.sbc.su.se/downloads/kalign/current.tar.gz                                                                         0.195 Resolving msa.sbc.su.se (msa.sbc.su.se)... 130.237.65.184                                                                                             
0.443 Connecting to msa.sbc.su.se (msa.sbc.su.se)|130.237.65.184|:80... connected.
0.565 HTTP request sent, awaiting response... 301 Moved Permanently
0.687 Location: https://msa.sbc.su.se/downloads/kalign/current.tar.gz [following]
0.687 --2024-07-09 10:26:50--  https://msa.sbc.su.se/downloads/kalign/current.tar.gz
0.724 Connecting to msa.sbc.su.se (msa.sbc.su.se)|130.237.65.184|:443... connected.
1.031 ERROR: The certificate of 'msa.sbc.su.se' is not trusted.                                                                                             
1.031 ERROR: The certificate of 'msa.sbc.su.se' has expired.                                                                                                
1.031 The certificate has expired                       
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
